### PR TITLE
Split core parts from interrupt crate into separate one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+**/*/target
 **/*.rs.bk
 **/release
 .vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,19 @@ matrix:
 
   include:
     - rust: nightly
-      env: 
-        - TARGET=armv7-unknown-linux-gnueabihf
-        - CFLAGS='-std=c11 -mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostartfiles -ffreestanding -mtune=cortex-a53'
-        - RUSTFLAGS='-C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon'
 
-script:
-  cargo build --target armv7-unknown-linux-gnueabihf --verbose
+script: ./travis-build.sh
+
+before_install:
+# clone latest ruspiro-singleton before build
+  - git clone https://github.com/RusPiRo/ruspiro-singleton.git ../ruspiro-singleton
 
 install:
+# install cross compiler toolchain
   - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+# install cargo xbuild to proper cross compile  
+  - cargo install cargo-xbuild
+# add the build target used for Raspbarry Pi targeting builds
   - rustup target add armv7-unknown-linux-gnueabihf
+  - rustup component add rust-src
+  - sudo chmod ugo+x ./travis-build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ matrix:
 
 script: ./travis-build.sh
 
-before_install:
-# clone latest ruspiro-singleton before build
-  - git clone https://github.com/RusPiRo/ruspiro-singleton.git ../ruspiro-singleton
-
 install:
 # install cross compiler toolchain
   - sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,22 +2,22 @@
 # It is not intended for manual editing.
 [[package]]
 name = "paste"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "paste-impl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "paste-impl"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -25,9 +25,9 @@ name = "proc-macro-hack"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -40,7 +40,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -56,21 +56,26 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "ruspiro-interrupt"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
- "paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruspiro-interrupt-core 0.2.0",
  "ruspiro-interrupt-macros 0.2.0",
  "ruspiro-register 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ruspiro-singleton 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruspiro-singleton 0.2.0",
 ]
+
+[[package]]
+name = "ruspiro-interrupt-core"
+version = "0.2.0"
 
 [[package]]
 name = "ruspiro-interrupt-macros"
@@ -82,8 +87,10 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-lock"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.0"
+dependencies = [
+ "ruspiro-interrupt-core 0.2.0",
+]
 
 [[package]]
 name = "ruspiro-register"
@@ -92,10 +99,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "ruspiro-singleton"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.2.0"
 dependencies = [
- "ruspiro-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ruspiro-interrupt-core 0.2.0",
+ "ruspiro-lock 0.2.0",
 ]
 
 [[package]]
@@ -110,11 +117,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.1"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -129,17 +136,15 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum paste 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "1f4a4a1c555c6505821f9d58b8779d0f630a6b7e4e1be24ba718610acf01fa79"
-"checksum paste-impl 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "26e796e623b8b257215f27e6c80a5478856cae305f5b59810ff9acdaa34570e6"
+"checksum paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "423a519e1c6e828f1e73b720f9d9ed2fa643dce8a7737fb43235ce0b41eeaa49"
+"checksum paste-impl 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "4214c9e912ef61bf42b81ba9a47e8aad1b2ffaf739ab162bf96d1e011f54e6c5"
 "checksum proc-macro-hack 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e688f31d92ffd7c1ddc57a1b4e6d773c0f2a14ee437a4b0a4f5a69c80eb221c8"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-"checksum proc-macro2 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "19f287c234c9b2d0308d692dee5c449c1a171167a6f8150f7cf2a49d8fd96967"
+"checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-"checksum quote 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7ab938ebe6f1c82426b5fb82eaf10c3e3028c53deaa3fbe38f5904b37cf4d767"
-"checksum ruspiro-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5655fe05fe4b90dc84698371cf0d7db487c6826933017ae199d908cb2a96e9bc"
+"checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
 "checksum ruspiro-register 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b980f28994eba9f2f2a7e539acdc2daf7903cd38dd173c24153d4a2a69f23414"
-"checksum ruspiro-singleton 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "03fbde4c1f1bc3a4cc88ad0e8f33e20ff7397a87a11b9856edea412e4bef863d"
 "checksum syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)" = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-"checksum syn 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "863ecbce06044c8380458360b4146d7372edadfedd77f120ba8c193da427b708"
+"checksum syn 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "ruspiro-interrupt"
-version = "0.2.2"
+version = "0.2.1"
 dependencies = [
  "paste 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ruspiro-interrupt-core 0.2.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ruspiro-interrupt"
 authors = ["Andre Borrmann <pspwizard@gmx.de>"]
-version = "0.2.2" # remember to update html_root_url
+version = "0.2.1" # remember to update html_root_url
 description = "Providing a simple and convinient way to implement interrupt handler for Raspberry Pi interrupts."
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.2"
-documentation = "https://docs.rs/ruspiro-interrupt/0.2.2"
+repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.1"
+documentation = "https://docs.rs/ruspiro-interrupt/0.2.1"
 readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "raspberrypi", "interrupt"]
 categories = ["no-std", "embedded"]
@@ -22,7 +22,7 @@ members = ["macros", "core"]
 
 [dependencies]
 paste = "0.1.5"
-ruspiro-register = "0.*"
+ruspiro-register = "0.1"
 ruspiro-interrupt-core = { path = "./core", version = "0.2" }
 ruspiro-interrupt-macros = { path = "./macros", version = "0.2" }
 ruspiro-singleton = { path = "../ruspiro-singleton", version = "0.2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,6 @@ edition = "2018"
 travis-ci = { repository = "RusPiRo/ruspiro-interrupt", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-#[workspace]
-#members = ["macros", "core"]
-
 [lib]
 
 [dependencies]
@@ -25,7 +22,7 @@ paste = "0.1.5"
 ruspiro-register = "0.1"
 ruspiro-interrupt-core = { path = "./core", version = "0.2" }
 ruspiro-interrupt-macros = { path = "./macros", version = "0.2" }
-ruspiro-singleton = { path = "../ruspiro-singleton", version = "0.2" }
+ruspiro-singleton = "0.2"
 
 [features]
 default = ["ruspiro_pi3"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ edition = "2018"
 travis-ci = { repository = "RusPiRo/ruspiro-interrupt", branch = "master" }
 maintenance = { status = "actively-developed" }
 
-[workspace]
-members = ["macros", "core"]
+#[workspace]
+#members = ["macros", "core"]
 
 [lib]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "ruspiro-interrupt"
 authors = ["Andre Borrmann <pspwizard@gmx.de>"]
-version = "0.2.0" # remember to update html_root_url
+version = "0.2.2" # remember to update html_root_url
 description = "Providing a simple and convinient way to implement interrupt handler for Raspberry Pi interrupts."
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.0"
-documentation = "https://docs.rs/ruspiro-interrupt/0.2.0"
+repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.2"
+documentation = "https://docs.rs/ruspiro-interrupt/0.2.2"
 readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "raspberrypi", "interrupt"]
 categories = ["no-std", "embedded"]
@@ -16,15 +16,16 @@ travis-ci = { repository = "RusPiRo/ruspiro-interrupt", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [workspace]
-members = ["macros"]
+members = ["macros", "core"]
 
 [lib]
 
 [dependencies]
 paste = "0.1.5"
-ruspiro-register = "0.1.1"
-ruspiro-interrupt-macros = { path = "./macros", version = "0.2.0" }
-ruspiro-singleton = "0.1.0"
+ruspiro-register = "0.*"
+ruspiro-interrupt-core = { path = "./core", version = "0.2" }
+ruspiro-interrupt-macros = { path = "./macros", version = "0.2" }
+ruspiro-singleton = { path = "../ruspiro-singleton", version = "0.2" }
 
 [features]
 default = ["ruspiro_pi3"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ script providing all the necessary linker symbols and entrypoints calling into t
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
 ```
 [dependencies]
-ruspiro-interrupt = "0.2.2"
+ruspiro-interrupt = "0.2"
 ```
 
 Once done the access to the features/attribute of the interrupt crate is available in your rust files like so:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ script providing all the necessary linker symbols and entrypoints calling into t
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
 ```
 [dependencies]
-ruspiro-interrupt = "0.2.0"
+ruspiro-interrupt = "0.2.2"
 ```
 
 Once done the access to the features/attribute of the interrupt crate is available in your rust files like so:
@@ -37,6 +37,9 @@ unsafe fn my_handler_for_source() {
 
 }
 ```
+
+The currently only implemented shared source interrupt line is the ``AUX`` interrupt. There the source could be one of:
+``Uart1``, ``Spi1`` or ``Spi2``.
 
 ## License
 Licensed under Apache License, Version 2.0, ([LICENSE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -4,7 +4,7 @@ authors = ["Andre Borrmann <pspwizard@gmx.de>"]
 version = "0.2.0" # remember to update html_root_url
 description = "Interrupt core functions to globally enable/disable interrupts on Raspberry Pi"
 license = "Apache-2.0"
-repository = "https://github.com/RusPiRo/ruspiro-interrupt-core/tree/v0.2.0"
+repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.1/core"
 documentation = "https://docs.rs/ruspiro-interrupt-core/0.2.0"
 readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "raspberrypi", "interrupt"]
@@ -12,7 +12,7 @@ categories = ["no-std", "embedded"]
 edition = "2018"
 
 [badges]
-travis-ci = { repository = "RusPiRo/ruspiro-interrupt-core", branch = "master" }
+travis-ci = { repository = "RusPiRo/ruspiro-interrupt", branch = "master" }
 maintenance = { status = "actively-developed" }
 
 [lib]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "ruspiro-interrupt-core"
+authors = ["Andre Borrmann <pspwizard@gmx.de>"]
+version = "0.2.0" # remember to update html_root_url
+description = "Interrupt core functions to globally enable/disable interrupts on Raspberry Pi"
+license = "Apache-2.0"
+repository = "https://github.com/RusPiRo/ruspiro-interrupt-core/tree/v0.2.0"
+documentation = "https://docs.rs/ruspiro-interrupt-core/0.2.0"
+readme = "README.md"
+keywords = ["RusPiRo", "baremetal", "raspberrypi", "interrupt"]
+categories = ["no-std", "embedded"]
+edition = "2018"
+
+[badges]
+travis-ci = { repository = "RusPiRo/ruspiro-interrupt-core", branch = "master" }
+maintenance = { status = "actively-developed" }
+
+[lib]
+
+[dependencies]
+
+[features]

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,32 @@
+# RusPiRo core interrupt crate
+
+Core interrupt functions to globally enable/disable interrupts to be triggered on Raspberry Pi. Splitting from the
+[``ruspiro-interrupt`` crate](https://crates.io/crates/ruspiro-interrupt) is necessary to prevent circular dependencies.
+
+[![Travis-CI Status](https://api.travis-ci.org/RusPiRo/ruspiro-interrupt.svg?branch=master)](https://travis-ci.org/RusPiRo/ruspiro-interrupt)
+[![Latest Version](https://img.shields.io/crates/v/ruspiro-interrupt-core.svg)](https://crates.io/crates/ruspiro-interrupt-core)
+[![Documentation](https://docs.rs/ruspiro-interrupt-core/badge.svg)](https://docs.rs/ruspiro-interrupt-core)
+[![License](https://img.shields.io/crates/l/ruspiro-interrupt-core.svg)](https://github.com/RusPiRo/ruspiro-interrupt-core#license)
+
+
+## Usage
+To use the crate just add the following dependency to your ``Cargo.toml`` file:
+```
+[dependencies]
+ruspiro-interrupt-core = "0.2"
+```
+
+Once done the access to the functions to enable/disable interrupts is available in your rust files like so:
+```
+use ruspiro_interrupt_core::*;
+
+fn demo() {
+    enable_interrupts();
+    disable_interrupts();
+    re_enable_interrupts();
+}
+
+```
+
+## License
+Licensed under Apache License, Version 2.0, ([LICENSE](LICENSE) or http://www.apache.org/licenses/LICENSE-2.0)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,0 +1,144 @@
+/*********************************************************************************************************************** 
+ * Copyright (c) 2019 by the authors
+ * 
+ * Author: André Borrmann 
+ * License: Apache License 2.0
+ **********************************************************************************************************************/
+#![doc(html_root_url = "https://docs.rs/ruspiro-interrupt-core/0.2.0")]
+#![no_std]
+#![feature(asm)]
+
+//! # Interrupt Core functions
+//! 
+//! Core functions to enable/disable interupts globally. This is splitted from the
+//! [``ruspiro-interrupt``](https://crates.io/crates/ruspiro-interrupt) crate to remove circular dependencies between
+//! the interrupt crate others (e.g. ``ruspiro-singleton``) crate.
+
+use core::sync::atomic::{AtomicBool, Ordering};
+
+// last IRQ state before globally disabling interrupts
+static IRQ_STATE: AtomicBool = AtomicBool::new(false);
+// last FAULT/FIQ state before globally disabling fast interrupts
+static FAULT_STATE: AtomicBool = AtomicBool::new(false);
+
+/// globally enabling interrupts (IRQ/FIQ) to be triggered
+pub fn enable_interrupts() {
+    enable_irq();
+    enable_fiq();
+}
+
+/// globally disabling interrupts (IRQ/FIQ) from beeing triggered
+pub fn disable_interrupts() {
+    disable_irq();
+    disable_fiq();
+}
+
+/// globally re-enabling interrupts (IRQ/FIQ) to be triggered. This is done based on the global state
+/// that was set before the interrupts were disable using the [``disable_interrupts``] function.
+pub fn re_enable_interrupts() {
+    re_enable_irq();
+    re_enable_fiq();
+}
+
+
+/// globally enable ``IRQ`` interrupts to be triggered
+pub fn enable_irq() {
+    #[cfg(target_arch="arm")]
+    unsafe { 
+        asm!("cpsie i
+              isb") // as per ARM spec the ISB ensures triggering pending interrupts
+    };
+}
+
+/// globally re-enabe ``IRQ`` interrupts to be triggered based on the global state that was set before disabling IRQ
+/// interrupts wihin the [``disable_irq``] function.
+pub fn re_enable_irq() {
+    // re-enable interrupts if they have been enabled prior to disabling
+    let state = IRQ_STATE.load(Ordering::SeqCst);
+
+    if state {
+        #[cfg(target_arch="arm")]
+        unsafe { 
+            asm!("cpsie i
+                isb") // as per ARM spec the ISB ensures triggering pending interrupts
+        }; 
+    }
+}
+
+/// globally enable ``FIQ`` interrupts to be triggered
+pub fn enable_fiq() {
+    #[cfg(target_arch="arm")]
+    unsafe { 
+        asm!("cpsie f
+              isb") // as per ARM spec the ISB ensures triggering pending interrupts
+    };
+}
+
+/// globally re-enabe ``FIQ`` interrupts to be triggered based on the global state that was set before disabling FIQ
+/// interrupts wihin the [``disable_fiq``] function.
+pub fn re_enable_fiq() {
+    // re-enable interrupts if they have been enabled prior to disabling
+    let state = FAULT_STATE.load(Ordering::SeqCst);
+
+    if state {
+        #[cfg(target_arch="arm")]
+        unsafe { 
+            asm!("cpsie f
+                isb") // as per ARM spec the ISB ensures triggering pending interrupts
+        }; 
+    }
+}
+
+/// globally disable ``IRQ`` interrupts from beeing triggered. This function stores the state of the current enabling/disabling
+/// of interrupts. If ``disable`` is called multiple times after each other this will than ultimately store "disabled" as
+/// last state. In this case a previous enabled state (before the multiple calls) is not able to recover with a call to [``re_enable_irq``].
+pub fn disable_irq() {
+    // remember the last IRQ state
+    let state = get_interrupt_state();
+
+    #[cfg(target_arch="arm")]
+    unsafe { asm!("cpsid i") };
+
+    // store the last interrupt state after interrupts have been
+    // disabled to ensure interrupt free atomic operation
+    IRQ_STATE.store(state != 0, Ordering::SeqCst);
+}
+
+/// globally disable ``FIQ`` interrupts from beeing triggered. This function stores the state of the current enabling/disabling
+/// of interrupts. If ``disable`` is called multiple times after each other this will than ultimately store "disabled" as
+/// last state. In this case a previous enabled state (before the multiple calls) is not able to recover with a call to [``re_enable_fiq``].
+pub fn disable_fiq() {
+    // remember the last FIQ state
+    let state = get_fault_state();
+
+    #[cfg(target_arch="arm")]
+    unsafe { asm!("cpsid f") };
+
+    // store the last interrupt state after interrupts have been
+    // disabled to ensure interrupt free atomic operation
+    FAULT_STATE.store(state != 0, Ordering::SeqCst);
+}
+
+#[allow(unreachable_code)]
+fn get_interrupt_state() -> u32 {
+    #[cfg(target_arch="arm")]
+    unsafe {
+        let state: u32;
+        asm!("MRS $0, CPSR":"=r"(state):::"volatile");
+        return state & 0x80;
+    }
+    // for non ARM targets there is nothing implemented to get current IRQ state, so return 0
+    0
+}
+
+#[allow(unreachable_code)]
+fn get_fault_state() -> u32 {    
+    #[cfg(target_arch="arm")]
+    unsafe {
+        let state: u32;
+        asm!("MRS $0, CPSR":"=r"(state):::"volatile");
+        return state & 0x40;
+    }
+    // for non ARM targets there is nothing implemented to get current IRQ state, so return 0
+    0
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -2,7 +2,10 @@
 name = "ruspiro-interrupt-macros"
 authors = ["Andre Borrmann <pspwizard@gmx.de>"]
 version = "0.2.0" # remember to update html_root_url
-description = "Macros used to implement interrupt handler. !!This crate is only useful in conjunction with the `ruspiro-interrupt` crate and shall never be used standalone!!"
+description = """
+Macros used to implement interrupt handler.
+!!This crate is only useful in conjunction with the `ruspiro-interrupt` crate and shall never be used standalone!!
+"""
 license = "Apache-2.0"
 repository = "https://github.com/RusPiRo/ruspiro-interrupt/tree/v0.2.0"
 documentation = "https://docs.rs/ruspiro-interrupt/0.2.0"

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -88,7 +88,9 @@ pub fn IrqHandler(attr: TokenStream, item: TokenStream) -> TokenStream {
             };
             let aux_source_s = aux_source.to_string();
             // check for valid Aux types
-            if &*aux_source_s != "Uart1" && &*aux_source_s != "Spi1" && &*aux_source_s != "Spi2" {
+            if &*aux_source_s != "Uart1" &&
+               &*aux_source_s != "Spi1" && 
+               &*aux_source_s != "Spi2" {
                 return syn::Error::new(syn::export::Span::call_site(), "Wrong source for `Aux` interrupt in `#[IrqHandler(Aux, <SOURCE>)`. <SOURCE> could be one of: `Uart1` | `Spi1` | `Spi2`.")
                         .to_compile_error()
                         .into()
@@ -133,7 +135,7 @@ pub fn IrqHandler(attr: TokenStream, item: TokenStream) -> TokenStream {
         pub unsafe fn #ident() {
             // force compiler error if the irq_name does not appear in the Interrupt enum that need to be
             // referred to in the crate using this attribute
-            crate::irqtypes::Interrupt::#irq_name;
+            self::irqtypes::Interrupt::#irq_name;
 
             #(#stmts)*
         }

--- a/src/auxhandler.rs
+++ b/src/auxhandler.rs
@@ -4,9 +4,10 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-//! # Aux interrupt line special handler
+//! # Aux interrupt line handler
 //! 
-//! The Aux interrupt line is shared between Uart1, Spi1 and Spi2. Therefore the 
+//! The Aux interrupt line is shared between Uart1, Spi1 and Spi2. This handler branches to the specific handler
+//! implementation based on the interrupt source.
 //! 
 
 use ruspiro_register::define_registers;
@@ -30,7 +31,7 @@ pub(crate) fn aux_handler() {
 }
 
 define_registers! [
-    AUX_IRQ:          ReadWrite<u32> @ PERIPHERAL_BASE + 0x0021_5000 => [
+    AUX_IRQ: ReadWrite<u32> @ PERIPHERAL_BASE + 0x0021_5000 => [
         SPI2    OFFSET(2),
         SPI1    OFFSET(1),
         UART1   OFFSET(0)

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -35,22 +35,6 @@ pub(crate) fn initialize() {
     CORE_MB_INT_CONTROL3::Register.set(1 << 3);
 }
 
-pub(crate) fn enable_i() {
-    unsafe { asm!("cpsie i") };
-}
-
-pub(crate) fn enable_f() {
-    unsafe { asm!("cpsie f") };
-}
-
-pub(crate) fn disable_i() {
-    unsafe { asm!("cpsid i") };
-}
-
-pub(crate) fn disable_f() {
-    unsafe { asm!("cpsid f") };
-}
-
 pub(crate) fn activate(bank: u32, irq_num: u32) {
     let enable_bit = 1 << (irq_num & 0x1F);
     match bank {

--- a/src/irqtypes.rs
+++ b/src/irqtypes.rs
@@ -1,16 +1,19 @@
-/* 
- * irqtypes.rs Copyright (c) 2019 by the authors
+/*********************************************************************************************************************** 
+ * Copyright (c) 2019 by the authors
  * 
  * Author: André Borrmann 
  * License: Apache License 2.0
- */
-//! # IRQ Types
-//! Defining the different possible IRQ's that can a handler could be registered for
+ **********************************************************************************************************************/
+
+//! # Interrupt Types
+//! 
+//! Defining the different possible interrupts of the Raspberry Pi a handler could be registered for.
+//! 
 
 /// The list of available interrupts on Raspberry Pi 3.
-/// Note: Even if it is possible to register an interrupt handler for them the behaviour is
-/// might be untested/undefined. Please read the corresponding specs for the different interrupts
-/// to understand how to acknowledge them inside the handler implementation.
+/// Note: Even if it is possible to register an interrupt handler for them the behaviour might be untested/undefined.
+/// Please read the corresponding specs for the different interrupts to understand how to acknowledge them inside the
+/// individual handler implementation.
 ///
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //!     println!("timer interrupt raised");
 //! }
 //! 
-//! fn demo() {
+//! fn doc() {
 //!     // as we have an interrupt handler defined we need to enable interrupt handling globally as well
 //!     // as the specific interrupt we have a handler implemented for
 //!     IRQ_MANAGER.take_for(|irq_mgr| {
@@ -40,10 +40,22 @@
 //! }
 //! ```
 //! 
+//! In some cases the interrupt type/line is shared between different sources. In those cases a handler need to be
+//! implemented for the specific interrupt source. The source is given in the custom attribute like this:
+//! ```
+//! #[IrqHandler(Aux, Uart1)]
+//! fn aux_uart1_handler() {
+//!     // implement Uart1 interrupt handler here
+//! }
+//! ```
+//! However, only a limited ammount of shared interrupts is available with the current version - which is only the **Aux**
+//! interrupt at the moment.
+//! 
 
 extern crate alloc;
 extern crate paste;
 
+pub use ruspiro_interrupt_core::*;
 pub use ruspiro_interrupt_macros::*;
 pub mod irqtypes;
 pub use irqtypes::*;
@@ -75,18 +87,6 @@ impl InterruptManager {
         interface::initialize();
     }
 
-    /// globally enable interrupts
-    pub fn enable(&self) {
-        interface::enable_i();
-        interface::enable_f();
-    }
-
-    /// globally disable interrupts
-    pub fn disable(&self) {
-        interface::disable_i();
-        interface::disable_f();
-    }
-
     /// activate a specific interrupt to be raised and handled (id a handler is implemented)
     /// if there is no handler implemented for this interrupt it may lead to an endless interrupt
     /// loop as the interrupt never gets acknowledged by the handler.
@@ -99,6 +99,8 @@ impl InterruptManager {
         interface::activate(irq_bank, irq_num);
         
         self.enabled[irq_bank as usize] |= 1 << (irq_num & 0x1F);
+        //println!("enabled Irq's: {:X}, {:X}, {:X}", self.enabled[0], self.enabled[1], self.enabled[2]);
+        #[cfg(target_arch="arm")]
         unsafe{ asm!("dmb") };
     }
 
@@ -111,6 +113,7 @@ impl InterruptManager {
         interface::deactivate(irq_bank, irq_num);
         
         self.enabled[irq_bank as usize] &= !(1 << (irq_num & 0x1F));
+        #[cfg(target_arch="arm")]
         unsafe{ asm!("dmb") };
     }
 }
@@ -126,9 +129,10 @@ impl InterruptManager {
 /// done somewhere else
 #[no_mangle]
 unsafe fn __interrupt_h(_core: u32) {
-    IRQ_MANAGER.use_weak_for(|mgr| {
+    IRQ_MANAGER.use_for(|mgr| {
         // check wheter the interrupt in a pending register really has been activiated
         let pendings: [u32; 3] = interface::get_pending_irqs();
+        //info!("irq raised. pending: {:X}, {:X}, {:X}", pendings[0], pendings[1], pendings[2]);
 
         // build a list of interrupt id's based on the bit's set in the 3 irq enable banks
         let active_irqs: Vec<u8> = (0..).zip(&pendings).fold(Vec::new(), |acc, p| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,12 @@
  * Author: André Borrmann 
  * License: Apache License 2.0
  **********************************************************************************************************************/
-#![doc(html_root_url = "https://docs.rs/ruspiro-interrupt/0.2.0")]
+#![doc(html_root_url = "https://docs.rs/ruspiro-interrupt/0.2.1")]
 #![no_std]
 #![feature(asm)]
 #![feature(linkage)]
 
-//! # Raspberry Pi Interrupt handler
+//! # Interrupt handler for Raspberry Pi
 //! 
 //! This crates provides functions and macros (custom attribute) to conviniently implement interrupt handler for 
 //! Raspberry Pi 3. The possible interrupts a handler can be implemented for are available as enum [irqtypes::Interrupt]
@@ -155,7 +155,7 @@ unsafe fn __interrupt_h(_core: u32) {
                 13  => __irq_handler__CoreSync1(),
                 14  => __irq_handler__CoreSync2(),
                 15  => __irq_handler__CoreSync3(),
-                29  => auxhandler::aux_handler(),//__irq_handler__Aux(),
+                29  => auxhandler::aux_handler(),
                 30  => __irq_handler__Arm(),
                 31  => __irq_handler__GpuDma(),
                 49  => __irq_handler__GpioBank0(),
@@ -249,215 +249,3 @@ default_handler_impl![
 fn __irq_handler_Default() {
 
 }
-
-/*
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__SystemTimer1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__SystemTimer3(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Isp(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Usb(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__CoreSync0(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__CoreSync1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__CoreSync2(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__CoreSync3(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Aux(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Arm(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__GpuDma(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__GpioBank0(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__GpioBank1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__GpioBank2(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__GpioBank3(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__I2c(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Spi(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__I2sPcm(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Sdio(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__Pl011(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmTimer(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmMailbox(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmDoorbell0(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmDoorbell1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmGpu0Halted(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmGpu1Halted(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmIllegalType1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmIllegalType0(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmPending1(){
-    __irq_handler_Default();
-}
-
-#[allow(non_snake_case)]
-#[linkage="weak"]
-#[no_mangle]
-extern "C" fn __irq_handler__ArmPending2(){
-    __irq_handler_Default();
-}
-*/

--- a/travis-build.sh
+++ b/travis-build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -ev
+
+export CFLAGS='-mfpu=neon-fp-armv8 -mfloat-abi=hard -march=armv8-a -Wall -O3 -nostdlib -nostartfiles -ffreestanding -mtune=cortex-a53'
+export RUSTFLAGS='-C linker=arm-linux-gnueabihf-gcc -C target-cpu=cortex-a53 -C target-feature=+a53,+fp-armv8,+v8,+vfp3,+d16,+thumb2,+neon -C link-arg=-nostartfiles -C opt-level=3 -C debuginfo=0'
+
+cargo xbuild --target armv7-unknown-linux-gnueabihf --verbose --release --all


### PR DESCRIPTION
Split the core parts from the interrupt crate intpo interrupt-core to remove circular dependencies when core interrupt functions (like global enable/disable) shall be used in other crates that are a dependencie of the interrupt crate.