### PR TITLE
Improve CI - PR build stability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,13 @@ matrix:
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
         - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
-      script: cargo test --tests --features pi3
+      script: cargo test --tests --features ruspiro_pi3
 
     - name: "doc tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
         - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
         - cat Cargo.toml
-      script: cargo test --doc --features pi3
+      script: cargo test --doc --features ruspiro_pi3
 
       

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
       script: cargo make --profile a64-travis pi3
 
     - name: "build 32Bit"
@@ -34,17 +34,17 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
       script: cargo make --profile a32 pi3
 
     - name: "unit tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
       script: cargo test --tests --features ruspiro_pi3
 
     - name: "doc tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
       script: cargo test --doc --features ruspiro_pi3

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
       script: cargo make --profile a64-travis pi3
 
     - name: "build 32Bit"
@@ -34,17 +34,20 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
       script: cargo make --profile a32 pi3
 
     - name: "unit tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
-      script: cargo test --tests --features ruspiro_pi3
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
+      script: cargo test --tests --features pi3
 
     - name: "doc tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "s/[patch.crates-io].*//g" Cargo.toml'
-      script: cargo test --doc --features ruspiro_pi3
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i "/^\[patch\.crates-io\]$/ {N; s/^.*//g}" Cargo.toml; fi'
+        - cat Cargo.toml
+      script: cargo test --doc --features pi3
+
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
       script: cargo make --profile a64-travis pi3
 
     - name: "build 32Bit"
@@ -34,17 +34,17 @@ matrix:
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
       script: cargo make --profile a32 pi3
 
     - name: "unit tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
       script: cargo test --tests --features ruspiro_pi3
 
     - name: "doc tests"
       install:
         # if we not build a PR we remove the patch of the dependencies to their github repo's
-        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
+        - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml
       script: cargo test --doc --features ruspiro_pi3

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ matrix:
         - rustup target add aarch64-unknown-linux-gnu
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
-        # remove local path in the dependencies of the cargo file to ensure we use the version from crates.io
-        - sed -i 's/path.*=.*"\.\{2\}.*", version/version/g' Cargo.toml
+        # if we not build a PR we remove the patch of the dependencies to their github repo's
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
       script: cargo make --profile a64-travis pi3
 
     - name: "build 32Bit"
@@ -33,18 +33,18 @@ matrix:
         - rustup target add armv7-unknown-linux-gnueabihf
         - rustup component add rust-src
         - rustup component add llvm-tools-preview
-        - sed -i 's/path.*=.*"\.\{2\}.*", version/version/g' Cargo.toml
-      # remove local path in the dependencies of the cargo file to ensure we use the version from crates.io
+        # if we not build a PR we remove the patch of the dependencies to their github repo's
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
       script: cargo make --profile a32 pi3
 
     - name: "unit tests"
       install:
-        # remove local path in the dependencies of the cargo file to ensure we use the version from crates.io
-        - sed -i 's/path.*=.*"\.\{2\}.*", version/version/g' Cargo.toml
+        # if we not build a PR we remove the patch of the dependencies to their github repo's
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
       script: cargo test --tests --features ruspiro_pi3
 
     - name: "doc tests"
       install:
-        # remove local path in the dependencies of the cargo file to ensure we use the version from crates.io
-        - sed -i 's/path.*=.*"\.\{2\}.*", version/version/g' Cargo.toml
+        # if we not build a PR we remove the patch of the dependencies to their github repo's
+        - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then sed -i 's/[patch.crates-io].*//g' Cargo.toml'
       script: cargo test --doc --features ruspiro_pi3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ readme = "README.md"
 keywords = ["RusPiRo", "baremetal", "raspberrypi", "interrupt"]
 categories = ["no-std", "embedded"]
 edition = "2018"
+exclude = [".travis.yml", "Makefile.toml"]
 
 [badges]
 travis-ci = { repository = "RusPiRo/ruspiro-interrupt", branch = "master" }
@@ -29,3 +30,7 @@ ruspiro-singleton = "0.3"
 [features]
 default = ["ruspiro_pi3"]
 ruspiro_pi3 = []
+
+[patch.crates-io]
+ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git" }
+ruspiro-singleton = { git ="https://github.com/RusPiRo/ruspiro-singleton.git"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ ruspiro_pi3 = []
 
 [patch.crates-io]
 ruspiro-register = { git = "https://github.com/RusPiRo/ruspiro-register.git" }
-ruspiro-singleton = { git ="https://github.com/RusPiRo/ruspiro-singleton.git"}
+ruspiro-singleton = { git ="https://github.com/RusPiRo/ruspiro-singleton.git" }

--- a/README.md
+++ b/README.md
@@ -15,13 +15,15 @@ script providing all the necessary linker symbols and entrypoints calling into t
 
 ## Usage
 To use the crate just add the following dependency to your ``Cargo.toml`` file:
-```
+
+```toml
 [dependencies]
 ruspiro-interrupt = "0.3"
 ```
 
 Once done the access to the features/attribute of the interrupt crate is available in your rust files like so:
-```
+
+```rust
 extern crate ruspiro_interrupt; // needed for proper linking of weak defined functions
 use ruspiro-interrupt::*;
 
@@ -32,7 +34,8 @@ unsafe fn my_handler() {
 ```
 
 In rare cases the interrupt line is shared for different sources, in this case the attribute need to specify the source:
-```
+
+```rust
 #[IrqHandler(<irq-type-name>, <source>)]
 unsafe fn my_handler_for_source() {
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,31 +266,31 @@ fn interrupt_handler() {
 
     if active[1] != 0 {
         // IRQ Bank 2
-        if active[1] & (1 << 49 - 32) != 0 {
+        if active[1] & (1 << (49 - 32)) != 0 {
             __irq_handler__GpioBank0()
         }
-        if active[1] & (1 << 50 - 32) != 0 {
+        if active[1] & (1 << (50 - 32)) != 0 {
             __irq_handler__GpioBank1()
         }
-        if active[1] & (1 << 51 - 32) != 0 {
+        if active[1] & (1 << (51 - 32)) != 0 {
             __irq_handler__GpioBank2()
         }
-        if active[1] & (1 << 52 - 32) != 0 {
+        if active[1] & (1 << (52 - 32)) != 0 {
             __irq_handler__GpioBank3()
         }
-        if active[1] & (1 << 53 - 32) != 0 {
+        if active[1] & (1 << (53 - 32)) != 0 {
             __irq_handler__I2c()
         }
-        if active[1] & (1 << 54 - 32) != 0 {
+        if active[1] & (1 << (54 - 32)) != 0 {
             __irq_handler__Spi()
         }
-        if active[1] & (1 << 55 - 32) != 0 {
+        if active[1] & (1 << (55 - 32)) != 0 {
             __irq_handler__I2sPcm()
         }
-        if active[1] & (1 << 56 - 32) != 0 {
+        if active[1] & (1 << (56 - 32)) != 0 {
             __irq_handler__Sdio()
         }
-        if active[1] & (1 << 57 - 32) != 0 {
+        if active[1] & (1 << (57 - 32)) != 0 {
             __irq_handler__Pl011()
         }
     }


### PR DESCRIPTION
Try to use github dependencies to dependend ruspiro crates for better PR build stability.
Only use published dependencies for the master build.