### PR TITLE
Fix github actions on branch builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,13 @@ jobs:
           # and the README.md
           sed -i -e 's/||VERSION||/'$CRATE_VERSION'/g' README.md
         
+      # as macros are published now - do the dry run for interrupt followed by the real publish
+      - name: Publish-Dry-Run
+        run: |
+          cd ./interrupt/
+          cargo make publish_dry --profile pipeline
+
       - name: Publish-Run
         run: |
-          cd ../interrupt/
+          cd ./interrupt/
           cargo make publish --env CRATES_TOKEN=${{ secrets.CRATES_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           version: 'latest'
 
-      - if: ${{ github.event_name != 'pull_request' }}
-        name: Remove patches if not a PR build
-        run: |
-          sed -i "/{^\[patch\.crates-io\] /{:a;N;/\Z}/!ba};/^ruspiro-.*\(git\|path\).*/d" ./interrupt/Cargo.toml;
+      # - if: ${{ github.event_name != 'pull_request' }}
+      #   name: Remove patches if not a PR build
+      #   run: |
+      #     sed -i "/{^\[patch\.crates-io\] /{:a;N;/\Z}/!ba};/^ruspiro-.*\(git\|path\).*/d" ./interrupt/Cargo.toml;
 
       - name: Compile
         run: |


### PR DESCRIPTION
As the interrupt crate likely depends on a new macro crate version that is not yet published to crates.io we need to keep the patches in the Cargo.toml file even on branch build. The patches are removed during publishing to crates.io at the very last step by `cargo publish` automatically.